### PR TITLE
Update plugin to be compatible with newer rider versions 2019.3+

### DIFF
--- a/RiderAutoAttach/resources/META-INF/plugin.xml
+++ b/RiderAutoAttach/resources/META-INF/plugin.xml
@@ -13,7 +13,7 @@
   </change-notes>
 
   <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-  <idea-version since-build="145.0"/>
+  <idea-version since-build="183"/>
 
   <depends>com.intellij.modules.lang</depends>
 


### PR DESCRIPTION
Updated the plugin to work with newer Rider versions as the original implementation did no longer work and some of the api used was deprecated. 

Also took the liberty to reformat the code a little (whitespace mainly).